### PR TITLE
remove null prefix and bump test

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: random_string
 description: Simple library for generating random ascii strings by default using Random from 'dart:math'.
-version: 2.2.0-nullsafety
+version: 2.3.0
 homepage: https://github.com/damondouglas/random_string.dart
 
 environment:
   sdk: '>=2.12.0-0 <3.0.0'
 
 dev_dependencies:
-  test: ^1.16.0-nullsafety.12
+  test: ^1.17.9


### PR DESCRIPTION
standard is to remove the null safety suffix, bumped version ready to upload to pub.dev

its been a while, lets get #17 closed